### PR TITLE
wget pymongo

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ issues_url 'https://github.com/signalfx/chef_install_configure_collectd/issues'
 license 'Apache-2.0'
 description 'Use this cookbook to install the SignalFx collectd agent and collectd plugins.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.4.2'
+version '0.4.3'
 
 supports "centos"
 supports "amazon"

--- a/recipes/config-mongodb.rb
+++ b/recipes/config-mongodb.rb
@@ -13,11 +13,17 @@ include_recipe 'chef_install_configure_collectd::default'
 
 install_python_pip
 
-pip_python_module("pymongo", "3.0.3")
+remote_file '/tmp/pymongo-3.0.3.tar.gz' do
+  source 'https://files.pythonhosted.org/packages/bd/91/1857471b63eaa192127c985b29362c094ae925720d5571daf286222c9716/pymongo-3.0.3.tar.gz'
+  owner "root"
+  group "root"
+  mode '0755'
+  action :create
+end
 
 bash 'extract_module' do
   code <<-EOH
-   pip-2.7 install pymongo==3.8.0
+   pip-2.6 install /tmp/pymongo-3.0.3.tar.gz
   EOH
 end
 

--- a/recipes/config-mongodb.rb
+++ b/recipes/config-mongodb.rb
@@ -13,6 +13,8 @@ include_recipe 'chef_install_configure_collectd::default'
 
 install_python_pip
 
+# Collectd uses packages in python2.6's path, however, we can't use pip2.6 to download packages from Pypi due to SNI requirements.
+# The workaround is to download pymongo package directly then have pip2.6 install it.
 remote_file '/tmp/pymongo-3.0.3.tar.gz' do
   source 'https://files.pythonhosted.org/packages/bd/91/1857471b63eaa192127c985b29362c094ae925720d5571daf286222c9716/pymongo-3.0.3.tar.gz'
   owner "root"


### PR DESCRIPTION
pip-2.6 does not support SNI and it will not able to download packages soon, and collected uses python2.6 by default(It'll take us more time to change `collectd`'s default behavior). A workaround for this issue would be getting pymongo's package from wget then install it.
 
wget pymongo package and use pip-2.6 to install it

Update: this solution works