### PR TITLE
feat: Point CollectD Metrics at our OpenTelemetry Gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v0.5.0
+* Point CollectD metrics at our OpenTelemetry Gateways
+
 ## v0.3.3
 * Adding support for Amazon Linux 2017.03 and all future versions
 
@@ -54,7 +57,7 @@
 ## v0.1.0:
 
 * Initial release.
-* Implement the basic 3 recipes to install collectd: 
+* Implement the basic 3 recipes to install collectd:
 - default recipe to install collectd-collectd
 - configure recipe to configure collectd
 - write-http recipe to configure the write-http plugin of collectd to send metrics to signalfx

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,19 @@
 default['write_http']['AWS_integration'] = true
-default['write_http']['Ingest_host'] = 'https://ingest.signalfx.com/v1/collectd'
+# We're trying to move away from being locked into the proprietary SignalFx metrics
+# product, and open up options to send our metrics anywhere.
+#
+# To do this we're running OpenTelemetry on Kubernetes that accepts CollectD
+# metrics and exports them to SignalFx, so in the future we could flip where they're
+# exported to.
+#
+# This also means that we only need to manage the SignalFx API key on the
+# Kubernetes deployment of OpenTelemetry rather than keep it up to date on
+# every server
+if node.chef_environment.downcase == "prod"
+  default['write_http']['Ingest_host'] = 'http://opentelemetry-collector.hudltools.com:8081'
+else
+  default['write_http']['Ingest_host'] = 'http://opentelemetry.app.thorhudl.com:8081'
+end
 default['write_http']['API_TOKEN'] = ''
 
 default['collectd_version'] = 'latest'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -12,7 +12,7 @@ default['write_http']['AWS_integration'] = true
 if node.chef_environment.downcase == "prod"
   default['write_http']['Ingest_host'] = 'http://opentelemetry-collector.app.hudl.com:8081'
 else
-  default['write_http']['Ingest_host'] = 'http://opentelemetry.app.thorhudl.com:8081'
+  default['write_http']['Ingest_host'] = 'http://opentelemetry-collector.app.thorhudl.com:8081'
 end
 default['write_http']['API_TOKEN'] = ''
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,7 +10,7 @@ default['write_http']['AWS_integration'] = true
 # Kubernetes deployment of OpenTelemetry rather than keep it up to date on
 # every server
 if node.chef_environment.downcase == "prod"
-  default['write_http']['Ingest_host'] = 'http://opentelemetry-collector.hudltools.com:8081'
+  default['write_http']['Ingest_host'] = 'http://opentelemetry-collector.app.hudl.com:8081'
 else
   default['write_http']['Ingest_host'] = 'http://opentelemetry.app.thorhudl.com:8081'
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ issues_url 'https://github.com/signalfx/chef_install_configure_collectd/issues'
 license 'Apache-2.0'
 description 'Use this cookbook to install the SignalFx collectd agent and collectd plugins.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.4.3'
+version '0.5.0'
 
 supports "centos"
 supports "amazon"


### PR DESCRIPTION
👋 

I believe this is the attribute we need to modify to point CollectD metrics at our OpenTelemetry Gateway rather than SignalFx directly.


<details>
  <summary>It's a fair deep chain of recipes ...</summary>

* MongoDB Instances (NOT configured by Aspen) run the `role_mongo` cookbook - https://github.com/hudl/role_mongo/blob/master/recipes/default.rb
* `role_mongo` calls `signalfx-cookbook::mongodb` - https://github.com/hudl/role_mongo/blob/master/recipes/default.rb#L71
* `signalfx-cookbook` calls `chef_install_configure_collectd::mongodb` - https://github.com/hudl/signalfx-cookbook/blob/master/recipes/mongodb.rb#L38
* `chef_install_configure_collectd::mongodb` calls `chef_install_configure_collectd::default` - https://github.com/hudl/chef_install_configure_collectd/blob/master/recipes/config-mongodb.rb#L12
* `chef_install_configure_collectd::default` calls `chef_install_configure_collectd::config-signalfx` - https://github.com/hudl/chef_install_configure_collectd/blob/master/recipes/default.rb#L59
* `chef_install_configure_collectd::config-signalfx` - Writes out a template with `INGEST_URL` - https://github.com/hudl/chef_install_configure_collectd/blob/master/recipes/config-signalfx.rb#L23
* `INGEST_URL` is determined by this call to `getHttpUri` -https://github.com/hudl/chef_install_configure_collectd/blob/master/recipes/config-signalfx.rb#L18 
* `getHttpUri` is defined here - https://github.com/hudl/chef_install_configure_collectd/blob/master/recipes/helper.rb#L69
* It reads the `node['write_http']['Ingest_host']` node attribute - https://github.com/hudl/chef_install_configure_collectd/blob/master/recipes/helper.rb#L88
* After configuring SignalFx `chef_install_configure_collectd::config-signalfx` then calls `chef_install_configure_collectd::config-write_http` - https://github.com/hudl/chef_install_configure_collectd/blob/master/recipes/config-signalfx.rb#L32
* This does an almost identical thing to write out a different configuration file with the `ingestUrl` - https://github.com/hudl/chef_install_configure_collectd/blob/master/recipes/config-write_http.rb#L22
</details>

<details>
  <summary>Thor Testing</summary>

* I manually edited the `/etc/collectd.d/managed_config/10-signalfx.conf` and `/etc/collectd.d/managed_config/10-write_http-plugin.conf` files on `/etc/collectd.d/managed_config/10-write_http-plugin.conf` to point to OpenTelemetry running on Thor

![Screenshot 2021-12-06 at 10 34 12](https://user-images.githubusercontent.com/851569/144831390-4bde32ee-66bb-4a40-b0ce-9e2d67133bd4.png)

* You can see the spike in requests to the loadbalancer after I made the change

![Screenshot 2021-12-06 at 10 37 02](https://user-images.githubusercontent.com/851569/144831741-a4bb2421-7332-4be6-85a0-a05ec9f99af4.png)

* In [SignalFx](https://app.signalfx.com/#/chart/v2/new?template=default&filters=aws_instance_id:i-04b04b9ed611389e0&filters=sf_metric:disk.utilization&startTime=-1w&endTime=Now) you can see the metrics for the instance, the gap is the time where I broke the metrics trying to workout the exact syntax needed

![Screenshot 2021-12-06 at 10 40 18](https://user-images.githubusercontent.com/851569/144832160-ffd26d52-6eeb-443d-9aa6-24fd5109f3d2.png)

* I'm fairly happy that these are the correct files to edit and once this PR has been applied - https://github.com/hudl/infra-eks-app-opentelemetry/pull/1 the metrics can make it to SignalFx

</details>

<details>
  <summary>Rollout and Release</summary>

* I believe that it's safe to release this cookbook to the Chef server once approved as we version lock `chef_install_configure_collectd` at the Environment level and nothing will automatically pick up this change 

![Screenshot 2021-12-06 at 10 44 31](https://user-images.githubusercontent.com/851569/144832687-d39d1d33-066a-4567-bc33-d871d0e150d2.png)

* Once this is approved and released to the Chef Server I'll update the `thor` version constraint on the Chef Server and use the Thor EC2 instances to workout the right Chef commands to release this, and come up with a rollout plan using SSM Agent to run the command everywhere 

</details>