### PR TITLE
fix: Add missing / to end of IngestURL for collectd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v0.5.1
+* Adding missing / to end of IngestURL for CollectD
+
 ## v0.5.0
 * Point CollectD metrics at our OpenTelemetry Gateways
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,9 +10,9 @@ default['write_http']['AWS_integration'] = true
 # Kubernetes deployment of OpenTelemetry rather than keep it up to date on
 # every server
 if node.chef_environment.downcase == "prod"
-  default['write_http']['Ingest_host'] = 'http://opentelemetry-collector.app.hudl.com:8081'
+  default['write_http']['Ingest_host'] = 'http://opentelemetry-collector.app.hudl.com:8081/'
 else
-  default['write_http']['Ingest_host'] = 'http://opentelemetry-collector.app.thorhudl.com:8081'
+  default['write_http']['Ingest_host'] = 'http://opentelemetry-collector.app.thorhudl.com:8081/'
 end
 default['write_http']['API_TOKEN'] = ''
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ issues_url 'https://github.com/signalfx/chef_install_configure_collectd/issues'
 license 'Apache-2.0'
 description 'Use this cookbook to install the SignalFx collectd agent and collectd plugins.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.5.0'
+version '0.5.1'
 
 supports "centos"
 supports "amazon"


### PR DESCRIPTION
I'm working through a Chef plan to check everything looks OK and I noticed the `/` is missing from the IngestURL

```
       <Module signalfx_metadata>
    -    URL "http://opentelemetry.app.thorhudl.com:8081/?sfxdim_AWSUniqueId=i-04b04b9ed611389e0_us-east-1_761584570493&sfxdim_chefUniqueId=hudl_t-users-mongo-rs1-use1e-05"
    +    URL "http://opentelemetry-collector.app.thorhudl.com:8081?sfxdim_AWSUniqueId=i-04b04b9ed611389e0_us-east-1_761584570493&sfxdim_chefUniqueId=hudl_t-users-mongo-rs1-use1e-05"
```

The `/` is important, I left it out during my manual testing and the ALB just rejects the request as not being a valid HTTP request, I'm guessing because it isn't valid to have a URL parameter after the port without a `/`