### PR TITLE
fix: WS-9160 - Ensure recipe can run on nodes that don't have a hudl attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v0.5.2
+* Ensure recipe can run on nodes that dont have a hudl attribute
+
 ## v0.5.1
 * Adding missing / to end of IngestURL for CollectD
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ issues_url 'https://github.com/signalfx/chef_install_configure_collectd/issues'
 license 'Apache-2.0'
 description 'Use this cookbook to install the SignalFx collectd agent and collectd plugins.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.5.1'
+version '0.5.2'
 
 supports "centos"
 supports "amazon"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,7 +17,7 @@ def get_collectd_conf_file
 end
 
 # required to work around issue with collectd logging on centos 7
-if node['platform'] == 'centos' and node['platform_version'].to_f >= 7.0 
+if node['platform'] == 'centos' and node['platform_version'].to_f >= 7.0
     node.override['SignalFx']['collectd']['logfile']['File'] =  "stdout"
 end
 
@@ -26,7 +26,7 @@ node.default['collectd_conf_folder'] = get_collectd_conf_folder
 node.default['collectd_managed_conf_folder'] = "#{node['collectd_conf_folder']}/managed_config"
 node.default['collectd_filtering_conf_folder'] = "#{node['collectd_conf_folder']}/filtering_config"
 
-if node[:hudl].fetch(:patch_signalfx_installation, false)
+if node.key?(:hudl) and node[:hudl].fetch(:patch_signalfx_installation, false)
   remote_file '/tmp/SignalFx-collectd-RPMs-AWS_EC2_Linux-release-latest.noarch.rpm' do
     source 'https://dl.signalfx.com/rpms/SignalFx-rpms/release/SignalFx-collectd-RPMs-AWS_EC2_Linux-release-latest.noarch.rpm'
     action :create


### PR DESCRIPTION
👋 

I think the fix is this easy, I'm no Ruby expert but I tried this in a ruby shell and I'm pretty sure it works

```
irb(main):001:0> map = {}
=> {}
irb(main):002:0> map.key?(:hudl)
=> false
irb(main):003:0> map[:hudl] = {}
=> {}
irb(main):004:0> map.key?(:hudl)
=> true
irb(main):005:0> map = {}
=> {}
irb(main):006:0> map.key?(:hudl)
=> false
irb(main):007:0> map.key?(:hudl) and true
=> false
```

I believe it's safe to do this on the existing nodes, because as far as I can tell no node actually has `patch_signalfx_installation` set

```
(ssm-run-chef) (⎈ |p-infra-tools:opentelemetry)aaronkalair@HUD040029 terraform-infra-opentelemetry % knife search node "hudl_patch_signalfx_installation:*"
0 items found
```

If you search for an alternative key in the hudl object that command does work, so I’m fairly certain my search is correct

```
(ssm-run-chef) (⎈ |p-infra-tools:opentelemetry)aaronkalair@HUD040029 terraform-infra-opentelemetry % knife search node "hudl_dns_domain:*"
490 items found
```